### PR TITLE
This commits adds a 'reset-block’ listener in mutliSelect to clear out

### DIFF
--- a/src/viewpoint/question-types/date/templates/ionic/date.html
+++ b/src/viewpoint/question-types/date/templates/ionic/date.html
@@ -13,15 +13,14 @@
                    />
 
             <input type="tel"
-                   ng-if="question.options.format === 'yyyy'" 
-                   ng-init="value = question.options.initial"
-                   placeholder="{{ question.label }}" 
-                   ng-model="value"
+                   ng-if="question.options.format === 'yyyy'"
+                   placeholder="{{ question.label }}"
+                   ng-model="$parent.value"
                    ng-required='question.options.required'
                    />
         </label>
     </div>
-      <div class="item item-divider" ng-show="errors.length>0"> 
+      <div class="item item-divider" ng-show="errors.length>0">
         <div class="error" ng-repeat="error in errors" class="error" >{{error}}</div>
       </div>
   </div>

--- a/src/viewpoint/services/vpApi-services.js
+++ b/src/viewpoint/services/vpApi-services.js
@@ -1,5 +1,5 @@
 /*
-    build timestamp: Tue Feb 03 2015 15:52:42 GMT-0800 (PST)
+    build timestamp: Wed Feb 04 2015 16:13:39 GMT-0800 (PST)
     build source: vp-survey
 */
 
@@ -46,7 +46,6 @@ angular.module('vpApi.services', [])
 
         obj.db.getCollection('answer').on('insert', function(item){
             item.id = obj.generateUUID();
-
         });
 
         return;
@@ -484,7 +483,6 @@ angular.module('vpApi.services', [])
         _.each(formResps, function(resp){
             $vpApi.db.getCollection('formResp').remove(resp);
         });
-
         _.each(blockResps, function(resp){
             $vpApi.db.getCollection('blockResp').remove(resp);
         });
@@ -494,6 +492,8 @@ angular.module('vpApi.services', [])
         });
 
         $vpApi.db.save();
+        console.log("[$fsResp.delete()] Deleted all responses. About to broadcast fsResp-deleted for " + fsRespId);
+        $rootScope.$broadcast('fsResp-deleted', {fsRespId: fsRespId});
     }
 
     this.getFullResp = function(fsRespId){


### PR DESCRIPTION
the directive when the block resets. It also cleaned up the date
template to use $parent.value and removed ng-init.
